### PR TITLE
feat: add product list and detail pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.env
+npm-debug.log
+backend/node_modules
+frontend/node_modules

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # product-selection-oversea
-基于跨境站选品
+
+基于跨境站选品示例项目，包含简单的后端和前端。
+
+## Backend
+
+位于 `backend/`，使用 Express 提供 `/products` 接口，支持分页、分类、关键字筛选，并提供 `/products/:id` 详情。
+
+```bash
+cd backend
+npm install
+npm start
+```
+
+## Frontend
+
+位于 `frontend/`，使用 Next.js 与 Zustand 实现商品列表和详情页。
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+`NEXT_PUBLIC_API_URL` 环境变量可用于自定义后端地址，默认为 `http://localhost:3001`。

--- a/backend/data/products.js
+++ b/backend/data/products.js
@@ -1,0 +1,52 @@
+export const products = [
+  {
+    id: 1,
+    name: 'Wireless Mouse',
+    category: 'electronics',
+    price: 25.99,
+    image: 'https://example.com/mouse.jpg',
+    sales: 1500,
+    source: 'Amazon',
+    description: 'A reliable wireless mouse'
+  },
+  {
+    id: 2,
+    name: 'Bluetooth Headphones',
+    category: 'electronics',
+    price: 59.99,
+    image: 'https://example.com/headphones.jpg',
+    sales: 800,
+    source: 'eBay',
+    description: 'Noise-cancelling over-ear headphones'
+  },
+  {
+    id: 3,
+    name: 'Running Shoes',
+    category: 'sports',
+    price: 89.99,
+    image: 'https://example.com/shoes.jpg',
+    sales: 1200,
+    source: 'Nike',
+    description: 'Lightweight running shoes'
+  },
+  {
+    id: 4,
+    name: 'Coffee Maker',
+    category: 'home',
+    price: 39.99,
+    image: 'https://example.com/coffee.jpg',
+    sales: 500,
+    source: 'Target',
+    description: 'Compact drip coffee maker'
+  },
+  {
+    id: 5,
+    name: 'Yoga Mat',
+    category: 'sports',
+    price: 19.99,
+    image: 'https://example.com/yoga.jpg',
+    sales: 900,
+    source: 'Walmart',
+    description: 'Non-slip yoga mat'
+  }
+];

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "product-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,48 @@
+import express from 'express';
+import cors from 'cors';
+import { products } from './data/products.js';
+
+const app = express();
+app.use(cors());
+
+// GET /products?category=&keyword=&page=&limit=
+app.get('/products', (req, res) => {
+  const { category, keyword, page = 1, limit = 10 } = req.query;
+  let filtered = products;
+
+  if (category) {
+    filtered = filtered.filter(p => p.category.toLowerCase() === category.toLowerCase());
+  }
+
+  if (keyword) {
+    const kw = keyword.toLowerCase();
+    filtered = filtered.filter(p => p.name.toLowerCase().includes(kw));
+  }
+
+  const pageNum = parseInt(page, 10);
+  const limitNum = parseInt(limit, 10);
+  const start = (pageNum - 1) * limitNum;
+  const paginated = filtered.slice(start, start + limitNum);
+
+  res.json({
+    data: paginated,
+    total: filtered.length,
+    page: pageNum,
+    limit: limitNum
+  });
+});
+
+// GET /products/:id - product detail
+app.get('/products/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const product = products.find(p => p.id === id);
+  if (!product) {
+    return res.status(404).json({ message: 'Product not found' });
+  }
+  res.json(product);
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "product-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "next": "^13.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.4.1"
+  }
+}

--- a/frontend/pages/products/[id].jsx
+++ b/frontend/pages/products/[id].jsx
@@ -1,0 +1,29 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+export default function ProductDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [product, setProduct] = useState(null);
+
+  useEffect(() => {
+    if (id) {
+      fetch(`${API_URL}/products/${id}`).then(res => res.json()).then(setProduct);
+    }
+  }, [id]);
+
+  if (!product) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1>{product.name}</h1>
+      <img src={product.image} alt={product.name} width="200" />
+      <p>Price: ${product.price}</p>
+      <p>Sales: {product.sales}</p>
+      <p>Source: {product.source}</p>
+      <p>{product.description}</p>
+    </div>
+  );
+}

--- a/frontend/pages/products/index.jsx
+++ b/frontend/pages/products/index.jsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+import { useEffect } from 'react';
+import { useProductStore } from '../../store/useProductStore';
+
+export default function ProductList() {
+  const {
+    products,
+    total,
+    page,
+    limit,
+    category,
+    keyword,
+    setCategory,
+    setKeyword,
+    setPage,
+    fetchProducts
+  } = useProductStore();
+
+  useEffect(() => {
+    fetchProducts();
+  }, [page]);
+
+  const totalPages = Math.ceil(total / limit);
+
+  return (
+    <div>
+      <h1>Products</h1>
+      <div style={{ marginBottom: '1rem' }}>
+        <input
+          placeholder="Category"
+          value={category}
+          onChange={e => setCategory(e.target.value)}
+        />
+        <input
+          placeholder="Keyword"
+          value={keyword}
+          onChange={e => setKeyword(e.target.value)}
+        />
+        <button onClick={() => { setPage(1); fetchProducts(); }}>Search</button>
+      </div>
+      <ul>
+        {products.map(p => (
+          <li key={p.id}>
+            <Link href={`/products/${p.id}`}>{p.name} - ${p.price}</Link>
+          </li>
+        ))}
+      </ul>
+      <div style={{ marginTop: '1rem' }}>
+        <button disabled={page <= 1} onClick={() => setPage(page - 1)}>Prev</button>
+        <span style={{ margin: '0 1rem' }}>{page} / {totalPages || 1}</span>
+        <button disabled={page >= totalPages} onClick={() => setPage(page + 1)}>Next</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/store/useProductStore.js
+++ b/frontend/store/useProductStore.js
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+export const useProductStore = create((set, get) => ({
+  products: [],
+  total: 0,
+  page: 1,
+  limit: 5,
+  category: '',
+  keyword: '',
+  setCategory: category => set({ category }),
+  setKeyword: keyword => set({ keyword }),
+  setPage: page => set({ page }),
+  fetchProducts: async () => {
+    const { page, limit, category, keyword } = get();
+    const params = new URLSearchParams({ page, limit });
+    if (category) params.append('category', category);
+    if (keyword) params.append('keyword', keyword);
+    const res = await fetch(`${API_URL}/products?${params.toString()}`);
+    const data = await res.json();
+    set({ products: data.data, total: data.total });
+  }
+}));


### PR DESCRIPTION
## Summary
- build Express backend with `/products` API supporting pagination, category and keyword filters
- expose `/products/:id` for product detail
- add Next.js frontend with list and detail pages powered by Zustand state

## Testing
- `npm test` (backend)
- `npm test` (frontend)
- `npm install` (backend) *(fails: 403 Forbidden fetching cors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1eb78b0488325945fad0f96ce1054