### PR TITLE
Init Next.js frontend and Express backend with Prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.next/
+.env

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # product-selection-oversea
+
 基于跨境站选品
+
+## 项目结构
+
+- `frontend/` - 基于 Next.js 的前端应用。
+- `backend/` - 基于 Express 的后端服务。
+
+## 开发
+
+### 前端
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+### 后端
+
+```bash
+cd backend
+npm install
+npm start
+```
+
+### 代码格式化
+
+在项目根目录运行：
+
+```bash
+npm test
+```
+
+该命令使用 Prettier 检查代码格式。

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "node src/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,0 +1,12 @@
+import express from 'express';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.send('Hello from Express');
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^14.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1>Welcome to Next.js</h1>;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "product-selection-oversea",
+  "version": "1.0.0",
+  "private": true,
+  "description": "基于跨境站选品",
+  "scripts": {
+    "lint": "prettier --check .",
+    "format": "prettier --write .",
+    "test": "prettier --check ."
+  },
+  "devDependencies": {
+    "prettier": "^3.3.2"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js app in `frontend`
- add Express server in `backend`
- set up repository configs and Prettier formatting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1eb6031108325a32a2040d0b7e890