### PR TITLE
Expand product views and add recommendations page

### DIFF
--- a/components/UploadForm.tsx
+++ b/components/UploadForm.tsx
@@ -22,7 +22,7 @@ export default function UploadForm() {
       setMessage(
         `Uploaded: ${fileId} (inserted: ${stats.inserted}, skipped: ${stats.skipped}, invalid: ${stats.invalid})`
       );
-      router.push(`/file/${fileId}?scheme=platform&minScore=55`);
+      router.push(`/recommended/${fileId}`);
     } catch (err: any) {
       setMessage(err.message);
     }

--- a/pages/product/[id].tsx
+++ b/pages/product/[id].tsx
@@ -13,17 +13,50 @@ export default function ProductPage() {
       .then(data => setRow(data.row));
   }, [id]);
   if (!row) return <p>Loading...</p>;
+  const entries = Object.entries(row.data || {}).filter(
+    ([k]) => !['ASIN', 'URL', 'Product Title'].includes(k)
+  );
   return (
     <>
       <Head>
         <title>{row.title}</title>
       </Head>
-      <main className="p-4 space-y-2">
+      <main className="p-4 space-y-4">
         <h1 className="text-2xl font-bold">{row.title}</h1>
-        <a href={row.url} className="text-blue-600" target="_blank" rel="noopener noreferrer">
-          {row.url}
-        </a>
-        <pre className="whitespace-pre-wrap bg-gray-100 p-4 border">{JSON.stringify(row.data, null, 2)}</pre>
+        {row.url && (
+          <a
+            href={row.url}
+            className="text-blue-600"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {row.url}
+          </a>
+        )}
+        <div className="border rounded p-4">
+          <table className="min-w-full">
+            <tbody>
+              <tr>
+                <th className="text-left pr-4">ASIN</th>
+                <td>{row.asin || row.data?.ASIN}</td>
+              </tr>
+              <tr>
+                <th className="text-left pr-4">Platform Score</th>
+                <td>{row.platform_score?.toFixed?.(2) ?? ''}</td>
+              </tr>
+              <tr>
+                <th className="text-left pr-4">Independent Score</th>
+                <td>{row.independent_score?.toFixed?.(2) ?? ''}</td>
+              </tr>
+              {entries.map(([k, v]) => (
+                <tr key={k}>
+                  <th className="text-left pr-4">{k}</th>
+                  <td>{String(v)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </main>
     </>
   );

--- a/pages/recommended/[id].tsx
+++ b/pages/recommended/[id].tsx
@@ -2,22 +2,20 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect, useState, useMemo } from 'react';
 
-export default function FilePage() {
+export default function RecommendedPage() {
   const router = useRouter();
-  const { id, scheme = 'platform', minScore = '0' } = router.query as {
-    id?: string;
-    scheme?: string;
-    minScore?: string;
-  };
+  const { id } = router.query as { id?: string };
   const [rows, setRows] = useState<any[]>([]);
+
   useEffect(() => {
     if (!id) return;
     fetch(`/api/files/${id}/rows`)
       .then(res => res.json())
       .then(data => setRows(data.rows || []));
   }, [id]);
-  const scoreKey = `${scheme}_score` as 'platform_score' | 'independent_score';
-  const min = Number(minScore);
+
+  const scoreKey = 'platform_score';
+  const min = 55;
 
   const columns = useMemo(() => {
     const set = new Set<string>();
@@ -36,10 +34,10 @@ export default function FilePage() {
   return (
     <>
       <Head>
-        <title>File {id}</title>
+        <title>Recommended Products for File {id}</title>
       </Head>
       <main className="p-4">
-        <h1 className="text-xl font-bold mb-4">File {id}</h1>
+        <h1 className="text-xl font-bold mb-4">Recommended Products for File {id}</h1>
         <table className="min-w-full border">
           <thead>
             <tr className="bg-gray-100">
@@ -100,3 +98,4 @@ export default function FilePage() {
     </>
   );
 }
+


### PR DESCRIPTION
## Summary
- show all available product fields and both score types on file detail table
- add a dedicated recommended products page filtered on platform score >=55
- present product detail data in a structured table

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a5736e1dc4832590b2cef471522167