### PR TITLE
feat: add global navigation and trend pages

### DIFF
--- a/app/api/trends/google/route.ts
+++ b/app/api/trends/google/route.ts
@@ -1,0 +1,12 @@
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const keyword = searchParams.get("keyword") || "";
+  const country = searchParams.get("country") || "";
+  const time = searchParams.get("time") || "";
+  const category = searchParams.get("category") || "";
+  const results = Array.from({ length: 5 }).map((_, i) => ({
+    term: keyword ? `${keyword} ${i + 1}` : `示例${i + 1}`,
+    value: Math.round(Math.random() * 100),
+  }));
+  return Response.json({ params: { country, time, category, keyword }, results });
+}

--- a/app/api/trends/tiktok/route.ts
+++ b/app/api/trends/tiktok/route.ts
@@ -1,0 +1,12 @@
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const keyword = searchParams.get("keyword") || "";
+  const country = searchParams.get("country") || "";
+  const time = searchParams.get("time") || "";
+  const category = searchParams.get("category") || "";
+  const results = Array.from({ length: 5 }).map((_, i) => ({
+    term: keyword ? `${keyword} ${i + 1}` : `示例${i + 1}`,
+    value: Math.round(Math.random() * 100),
+  }));
+  return Response.json({ params: { country, time, category, keyword }, results });
+}

--- a/app/keywords/page.tsx
+++ b/app/keywords/page.tsx
@@ -1,0 +1,3 @@
+export default function KeywordsPage() {
+  return <div className="p-6">关键词推荐页面</div>;
+}

--- a/app/trends/TrendsNav.tsx
+++ b/app/trends/TrendsNav.tsx
@@ -1,0 +1,32 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const items = [
+  { href: "/trends/google", label: "Google Trend" },
+  { href: "/trends/tiktok", label: "TikTok Trend" },
+];
+
+export default function TrendsNav() {
+  const pathname = usePathname();
+  return (
+    <nav className="mb-4 flex gap-4 border-b border-[var(--border)]">
+      {items.map((item) => {
+        const active = pathname.startsWith(item.href);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={
+              active
+                ? "pb-1 text-blue-600 border-b-2 border-blue-600"
+                : "pb-1 text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            }
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/app/trends/google/page.tsx
+++ b/app/trends/google/page.tsx
@@ -1,0 +1,72 @@
+"use client";
+import { useState } from "react";
+
+export default function GoogleTrendPage() {
+  const [form, setForm] = useState({
+    country: "",
+    time: "",
+    category: "",
+    keyword: "",
+  });
+  const [data, setData] = useState<{ term: string; value: number }[]>([]);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const params = new URLSearchParams(form);
+    const res = await fetch(`/api/trends/google?${params.toString()}`);
+    const json = await res.json();
+    setData(json.results || []);
+  };
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={handleSubmit} className="flex flex-wrap gap-2 items-end">
+        <input
+          name="keyword"
+          value={form.keyword}
+          onChange={handleChange}
+          placeholder="关键词"
+          className="border p-1"
+        />
+        <input
+          name="country"
+          value={form.country}
+          onChange={handleChange}
+          placeholder="国家"
+          className="border p-1"
+        />
+        <input
+          name="time"
+          value={form.time}
+          onChange={handleChange}
+          placeholder="时间周期"
+          className="border p-1"
+        />
+        <input
+          name="category"
+          value={form.category}
+          onChange={handleChange}
+          placeholder="类目"
+          className="border p-1"
+        />
+        <button type="submit" className="px-2 py-1 border">
+          查询
+        </button>
+      </form>
+      <ul className="list-disc pl-4">
+        {data.map((d, i) => (
+          <li key={i}>
+            {d.term}: {d.value}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/trends/layout.tsx
+++ b/app/trends/layout.tsx
@@ -1,0 +1,10 @@
+import TrendsNav from "./TrendsNav";
+
+export default function TrendsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="p-6">
+      <TrendsNav />
+      {children}
+    </div>
+  );
+}

--- a/app/trends/page.tsx
+++ b/app/trends/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function TrendsPage() {
+  redirect("/trends/google");
+}

--- a/app/trends/tiktok/page.tsx
+++ b/app/trends/tiktok/page.tsx
@@ -1,0 +1,72 @@
+"use client";
+import { useState } from "react";
+
+export default function TiktokTrendPage() {
+  const [form, setForm] = useState({
+    country: "",
+    time: "",
+    category: "",
+    keyword: "",
+  });
+  const [data, setData] = useState<{ term: string; value: number }[]>([]);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const params = new URLSearchParams(form);
+    const res = await fetch(`/api/trends/tiktok?${params.toString()}`);
+    const json = await res.json();
+    setData(json.results || []);
+  };
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={handleSubmit} className="flex flex-wrap gap-2 items-end">
+        <input
+          name="keyword"
+          value={form.keyword}
+          onChange={handleChange}
+          placeholder="关键词"
+          className="border p-1"
+        />
+        <input
+          name="country"
+          value={form.country}
+          onChange={handleChange}
+          placeholder="国家"
+          className="border p-1"
+        />
+        <input
+          name="time"
+          value={form.time}
+          onChange={handleChange}
+          placeholder="时间周期"
+          className="border p-1"
+        />
+        <input
+          name="category"
+          value={form.category}
+          onChange={handleChange}
+          placeholder="类目"
+          className="border p-1"
+        />
+        <button type="submit" className="px-2 py-1 border">
+          查询
+        </button>
+      </form>
+      <ul className="list-disc pl-4">
+        {data.map((d, i) => (
+          <li key={i}>
+            {d.term}: {d.value}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/Topbar.tsx
+++ b/components/Topbar.tsx
@@ -1,7 +1,35 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const navItems = [
+  { href: "/recommendations", label: "选品" },
+  { href: "/trends", label: "趋势" },
+  { href: "/keywords", label: "关键词推荐" },
+];
+
 export default function Topbar() {
+  const pathname = usePathname();
   return (
     <header className="h-12 border-b border-[var(--border)] bg-[var(--background)] flex items-center px-4">
-      <span className="font-medium">选品平台</span>
+      <nav className="flex gap-4">
+        {navItems.map((item) => {
+          const active = pathname.startsWith(item.href);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={
+                active
+                  ? "text-blue-600 font-medium"
+                  : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+              }
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- add top navigation with links for product selection, trends, and keyword suggestions
- create trends section with Google and TikTok sub-pages including filters for country, time, category and keyword
- expose mock trend APIs and add placeholder keyword recommendation page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden for @supabase/supabase-js)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8d3906d08325888855e6b783b499