### PR TITLE
Use inserted timestamp in blackbox rows view

### DIFF
--- a/sql/20241017_alter_blackbox_rows.sql
+++ b/sql/20241017_alter_blackbox_rows.sql
@@ -44,7 +44,7 @@ SELECT
   r.id AS row_id,
   r.file_id,
   r.row_index,
-  r.created_at,
+  r.inserted_at AS created_at,
   r.asin,
   r.url,
   r.title,


### PR DESCRIPTION
## Summary
- select `inserted_at` as `created_at` in `v_blackbox_rows_with_scores`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `psql -f sql/20241017_alter_blackbox_rows.sql` *(fails: command not found; attempted to install `postgresql-client` but apt repositories inaccessible)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf4369e108325b60c5cd21fecb6a4