### PR TITLE
feat: fetch latest products from supabase

### DIFF
--- a/pages/api/products/latest.ts
+++ b/pages/api/products/latest.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '@/lib/supabase';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET')
+    return res.status(405).json({ error: 'Method Not Allowed' });
+
+  const {
+    platformMin,
+    platformMax,
+    independentMin,
+    independentMax,
+    keyword,
+    category,
+    recommend,
+  } = req.query;
+
+  let query = supabase
+    .from('v_blackbox_rows_with_scores')
+    .select(
+      'row_id,url,image_url,asin,title,brand,shipping,category,price,review_count,review_rating,third_party_seller,seller_country,active_seller_count,size_tier,length,width,height,weight,age_months,platform_score,independent_score,imported_at'
+    );
+
+  if (platformMin) query = query.gte('platform_score', Number(platformMin));
+  if (platformMax) query = query.lte('platform_score', Number(platformMax));
+  if (independentMin) query = query.gte('independent_score', Number(independentMin));
+  if (independentMax) query = query.lte('independent_score', Number(independentMax));
+  if (keyword) query = query.ilike('title', `%${keyword}%`);
+  if (category) query = query.eq('category', category as string);
+  if (recommend) query = query.gte('platform_score', 55);
+
+  const { data, error } = await query
+    .order('imported_at', { ascending: false })
+    .limit(200);
+
+  if (error) return res.status(500).json({ error: error.message });
+
+  return res.status(200).json({ rows: data });
+}

--- a/pages/api/products/rescore.ts
+++ b/pages/api/products/rescore.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '@/lib/supabase';
+import { computeScores } from '@/lib/scoring';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method Not Allowed' });
+
+  const { data: rows, error: rowsErr } = await supabase.from('blackbox_rows').select('id, data');
+  if (rowsErr) return res.status(500).json({ error: rowsErr.message });
+
+  const { data: existingScores, error: scoresErr } = await supabase
+    .from('product_scores')
+    .select('row_id, platform_score, independent_score');
+  if (scoresErr) return res.status(500).json({ error: scoresErr.message });
+
+  const map = new Map(existingScores.map((s) => [s.row_id, s]));
+  let rescored = 0;
+
+  for (const row of rows) {
+    const s = map.get(row.id);
+    if (!s || s.platform_score === 0 || s.independent_score === 0) {
+      const scores = computeScores(row.data as any);
+      if (scores.platform_score === 0 && scores.independent_score === 0) continue;
+      await supabase.from('product_scores').upsert({ row_id: row.id, ...scores });
+      rescored++;
+    }
+  }
+
+  return res.status(200).json({ rescored });
+}

--- a/sql/20241027_add_indexes.sql
+++ b/sql/20241027_add_indexes.sql
@@ -1,0 +1,5 @@
+CREATE INDEX IF NOT EXISTS idx_blackbox_rows_imported_at
+  ON blackbox_rows (imported_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_product_scores_platform_score
+  ON product_scores (platform_score DESC);

--- a/sql/20241027_add_indexes.sql
+++ b/sql/20241027_add_indexes.sql
@@ -1,5 +1,5 @@
 CREATE INDEX IF NOT EXISTS idx_blackbox_rows_imported_at
   ON blackbox_rows (imported_at DESC);
 
-CREATE INDEX IF NOT EXISTS idx_product_scores_platform_score
-  ON product_scores (platform_score DESC);
+CREATE INDEX IF NOT EXISTS idx_product_scores_platform_score_row_id
+  ON product_scores (platform_score DESC, row_id);

--- a/sql/20241028_add_file_status.sql
+++ b/sql/20241028_add_file_status.sql
@@ -1,0 +1,3 @@
+alter table if exists blackbox_files
+  add column if not exists status text,
+  add column if not exists processed_at timestamptz;


### PR DESCRIPTION
## Summary
- add `/api/products/latest` endpoint to load latest products from Supabase
- refactor product and recommendation pages to use new endpoint and drop mock fallback
- add database indexes for imported time and platform score

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab1ed4c8b883259f24c2595b8f029e