### PR TITLE
Add product rescoring and latest products API

### DIFF
--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -92,7 +92,13 @@ export default function ProductsPage() {
         }));
         setAll(mapped);
         if (!categories.length) {
-          const unique = Array.from(new Set(mapped.map((p) => p.category).filter(Boolean)));
+          const unique = Array.from(
+            new Set(
+              mapped
+                .map((p) => p.category)
+                .filter((c): c is string => Boolean(c))
+            )
+          );
           setCategories(unique);
         }
       } catch (err) {

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -46,6 +46,7 @@ export default function ProductsPage() {
     category: '',
   });
   const [filters, setFilters] = useState(draft);
+  const [status, setStatus] = useState<'loading' | 'loaded'>('loading');
 
   useEffect(() => {
     async function loadCategories() {
@@ -63,6 +64,7 @@ export default function ProductsPage() {
   useEffect(() => {
     async function load() {
       try {
+        setStatus('loading');
         const res = await fetch('/api/products/latest').then((r) => r.json());
         const rows = res.items || [];
         const mapped: Product[] = rows.map((r: any) => ({
@@ -103,6 +105,8 @@ export default function ProductsPage() {
         }
       } catch (err) {
         console.error('fetch latest failed', err);
+      } finally {
+        setStatus('loaded');
       }
     }
     load();
@@ -167,6 +171,9 @@ export default function ProductsPage() {
   return (
     <div className="p-6 space-y-4 overflow-auto">
       <h1 className="text-2xl font-semibold">产品列表</h1>
+      <div className="text-sm text-gray-500">
+        {status === 'loading' ? '加载中，请等待...' : '加载完成'}
+      </div>
       <div className="flex flex-wrap items-end gap-2">
         <div>
           <label className="block text-xs">平台评分</label>
@@ -347,7 +354,14 @@ export default function ProductsPage() {
                 </td>
               </tr>
             ))}
-            {!display.length && (
+            {status === 'loading' && (
+              <tr>
+                <td className="p-2 text-center" colSpan={20}>
+                  加载中，请等待...
+                </td>
+              </tr>
+            )}
+            {status === 'loaded' && !display.length && (
               <tr>
                 <td className="p-2 text-center" colSpan={20}>
                   暂无数据

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
 import ScoreBadge from "@/components/ScoreBadge";
-import mockProducts from "@/app/api/mock/products.json";
 
 type Product = {
   id: string;
@@ -30,6 +29,7 @@ type Product = {
 };
 
 export default function ProductsPage() {
+  const [all, setAll] = useState<Product[]>([]);
   const [items, setItems] = useState<Product[]>([]);
   const [sortKey, setSortKey] = useState<keyof Product | null>(null);
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
@@ -53,109 +53,69 @@ export default function ProductsPage() {
         const res = await fetch('/api/categories').then((r) => r.json());
         if (Array.isArray(res.categories) && res.categories.length) {
           setCategories(res.categories);
-          return;
         }
       } catch (err) {
         console.error('fetch categories failed', err);
       }
-      const unique = Array.from(
-        new Set(
-          (mockProducts.items || []).map((p: any) => p.category).filter(Boolean)
-        )
-      );
-      setCategories(unique);
     }
     loadCategories();
   }, []);
   useEffect(() => {
     async function load() {
       try {
-        const files = await fetch('/api/files').then((r) => r.json());
-        if (Array.isArray(files) && files.length) {
-          const latest = files[0];
-          const params = new URLSearchParams({
-            page: String(page),
-            limit: String(limit),
-          });
-          Object.entries(filters).forEach(([k, v]) => {
-            if (v) params.set(k, v);
-          });
-          const res = await fetch(
-            `/api/files/${latest.id}/rows?${params.toString()}`
-          ).then((r) => r.json());
-          const rows = res.rows || [];
-          const mapped: Product[] = rows.map((r: any) => ({
-            id: r.row_id,
-            url: r.url ?? null,
-            image_url: r.image_url ?? null,
-            asin: r.asin ?? null,
-            title: r.title ?? null,
-            brand: r.brand ?? null,
-            shipping: r.shipping ?? null,
-            category: r.category ?? null,
-            price: r.price ?? null,
-            review_count: r.review_count ?? null,
-            review_rating: r.review_rating ?? null,
-            third_party_seller: r.third_party_seller ?? null,
-            seller_country: r.seller_country ?? null,
-            active_seller_count: r.active_seller_count ?? null,
-            size_tier: r.size_tier ?? null,
-            length: r.length ?? null,
-            width: r.width ?? null,
-            height: r.height ?? null,
-            weight: r.weight ?? null,
-            age_months: r.age_months ?? null,
-            platform_score: r.platform_score ?? null,
-            independent_score: r.independent_score ?? null,
-            imported_at: r.imported_at ?? null,
-          }));
-          setItems(mapped);
-          setTotal(res.count || 0);
-          return;
+        const res = await fetch('/api/products/latest').then((r) => r.json());
+        const rows = res.items || [];
+        const mapped: Product[] = rows.map((r: any) => ({
+          id: r.row_id,
+          url: r.url ?? null,
+          image_url: r.image_url ?? null,
+          asin: r.asin ?? null,
+          title: r.title ?? null,
+          brand: r.brand ?? null,
+          shipping: r.shipping ?? null,
+          category: r.category ?? null,
+          price: r.price ?? null,
+          review_count: r.review_count ?? null,
+          review_rating: r.review_rating ?? null,
+          third_party_seller: r.third_party_seller ?? null,
+          seller_country: r.seller_country ?? null,
+          active_seller_count: r.active_seller_count ?? null,
+          size_tier: r.size_tier ?? null,
+          length: r.length ?? null,
+          width: r.width ?? null,
+          height: r.height ?? null,
+          weight: r.weight ?? null,
+          age_months: r.age_months ?? null,
+          platform_score: r.platform_score ?? null,
+          independent_score: r.independent_score ?? null,
+          imported_at: r.imported_at ?? null,
+        }));
+        setAll(mapped);
+        if (!categories.length) {
+          const unique = Array.from(new Set(mapped.map((p) => p.category).filter(Boolean)));
+          setCategories(unique);
         }
       } catch (err) {
-        console.error('fetch rows failed', err);
+        console.error('fetch latest failed', err);
       }
-      const all: Product[] = (mockProducts.items || []).map((r: any) => ({
-        id: r.id,
-        url: r.url ?? null,
-        image_url: r.image ?? null,
-        asin: r.asin ?? null,
-        title: r.title ?? null,
-        brand: r.brand ?? null,
-        shipping: r.shipping ?? null,
-        category: r.category ?? null,
-        price: r.price ?? null,
-        review_count: r.review_count ?? null,
-        review_rating: r.review_rating ?? null,
-        third_party_seller: r.third_party_seller ?? null,
-        seller_country: r.seller_country ?? null,
-        active_seller_count: r.seller_count ?? null,
-        size_tier: r.size ?? null,
-        length: r.length ?? null,
-        width: r.width ?? null,
-        height: r.height ?? null,
-        weight: r.weight_kg ?? null,
-        age_months: r.age_months ?? null,
-        platform_score: r.platform_score ?? r.score ?? null,
-        independent_score: r.independent_score ?? null,
-        imported_at: r.synced_at ?? null,
-      }));
-      const filtered = all.filter((p) => {
-        if (filters.platformMin && (p.platform_score ?? 0) < Number(filters.platformMin)) return false;
-        if (filters.platformMax && (p.platform_score ?? 0) > Number(filters.platformMax)) return false;
-        if (filters.independentMin && (p.independent_score ?? 0) < Number(filters.independentMin)) return false;
-        if (filters.independentMax && (p.independent_score ?? 0) > Number(filters.independentMax)) return false;
-        if (filters.keyword && !(p.title ?? '').includes(filters.keyword)) return false;
-        if (filters.category && p.category !== filters.category) return false;
-        return true;
-      });
-      const start = (page - 1) * limit;
-      setItems(filtered.slice(start, start + limit));
-      setTotal(filtered.length);
     }
     load();
-  }, [page, limit, filters]);
+  }, []);
+
+  useEffect(() => {
+    const filtered = all.filter((p) => {
+      if (filters.platformMin && (p.platform_score ?? 0) < Number(filters.platformMin)) return false;
+      if (filters.platformMax && (p.platform_score ?? 0) > Number(filters.platformMax)) return false;
+      if (filters.independentMin && (p.independent_score ?? 0) < Number(filters.independentMin)) return false;
+      if (filters.independentMax && (p.independent_score ?? 0) > Number(filters.independentMax)) return false;
+      if (filters.keyword && !(p.title ?? '').includes(filters.keyword)) return false;
+      if (filters.category && p.category !== filters.category) return false;
+      return true;
+    });
+    const start = (page - 1) * limit;
+    setItems(filtered.slice(start, start + limit));
+    setTotal(filtered.length);
+  }, [all, page, limit, filters]);
 
   function handleSort(key: keyof Product) {
     if (sortKey === key) setSortDir(sortDir === 'asc' ? 'desc' : 'asc');

--- a/app/recommendations/page.tsx
+++ b/app/recommendations/page.tsx
@@ -86,7 +86,13 @@ export default function RecommendationsPage() {
         }));
         setAll(mapped);
         if (!categories.length) {
-          const unique = Array.from(new Set(mapped.map((p) => p.category).filter(Boolean)));
+          const unique = Array.from(
+            new Set(
+              mapped
+                .map((p) => p.category)
+                .filter((c): c is string => Boolean(c))
+            )
+          );
           setCategories(unique);
         }
       } catch (err) {

--- a/app/recommendations/page.tsx
+++ b/app/recommendations/page.tsx
@@ -39,6 +39,7 @@ export default function RecommendationsPage() {
   const [categories, setCategories] = useState<string[]>([]);
   const [draft, setDraft] = useState({ keyword: '', category: '' });
   const [filters, setFilters] = useState(draft);
+  const [status, setStatus] = useState<'loading' | 'loaded'>('loading');
 
   useEffect(() => {
     async function loadCategories() {
@@ -57,6 +58,7 @@ export default function RecommendationsPage() {
   useEffect(() => {
     async function load() {
       try {
+        setStatus('loading');
         const res = await fetch('/api/products/latest?recommend=1').then((r) => r.json());
         const rows = res.items || [];
         const mapped: Product[] = rows.map((r: any) => ({
@@ -97,6 +99,8 @@ export default function RecommendationsPage() {
         }
       } catch (err) {
         console.error('fetch latest failed', err);
+      } finally {
+        setStatus('loaded');
       }
     }
     load();
@@ -157,6 +161,9 @@ export default function RecommendationsPage() {
   return (
     <div className="p-6 space-y-4 overflow-auto">
       <h1 className="text-2xl font-semibold">推荐产品</h1>
+      <div className="text-sm text-gray-500">
+        {status === 'loading' ? '加载中，请等待...' : '加载完成'}
+      </div>
       <div className="flex flex-wrap items-end gap-2">
         <div>
           <label className="block text-xs">产品名</label>
@@ -296,6 +303,20 @@ export default function RecommendationsPage() {
               <td className="p-2">{p.imported_at ?? '-'}</td>
             </tr>
           ))}
+          {status === 'loading' && (
+            <tr>
+              <td className="p-2 text-center" colSpan={20}>
+                加载中，请等待...
+              </td>
+            </tr>
+          )}
+          {status === 'loaded' && !display.length && (
+            <tr>
+              <td className="p-2 text-center" colSpan={20}>
+                暂无数据
+              </td>
+            </tr>
+          )}
         </tbody>
       </table>
 

--- a/pages/api/products/latest.ts
+++ b/pages/api/products/latest.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '@/lib/supabase';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method Not Allowed' });
+
+  try {
+    let query = supabase
+      .from('v_blackbox_rows_with_scores')
+      .select('row_id, url, image_url, asin, title, platform_score, independent_score, imported_at')
+      .order('imported_at', { ascending: false })
+      .limit(200);
+
+    if ('recommend' in req.query) {
+      query = query.gte('platform_score', 55);
+    }
+
+    const { data, error } = await query;
+    if (error) return res.status(500).json({ error: error.message });
+
+    return res.status(200).json({ items: data || [] });
+  } catch (e: any) {
+    return res.status(500).json({ error: e.message });
+  }
+}

--- a/pages/api/products/rescore.ts
+++ b/pages/api/products/rescore.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '@/lib/supabase';
+import { computeScores } from '@/lib/scoring';
+
+const BATCH_SIZE = 500;
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method Not Allowed' });
+
+  try {
+    let lastId: number | null = null;
+    let processed = 0;
+
+    while (true) {
+      let query = supabase
+        .from('v_blackbox_rows_with_scores')
+        .select('*')
+        .or('platform_score.is.null,platform_score.eq.0,independent_score.is.null,independent_score.eq.0')
+        .order('row_id', { ascending: true })
+        .limit(BATCH_SIZE);
+      if (lastId) query = query.gt('row_id', lastId);
+
+      const { data, error } = await query;
+      if (error) throw error;
+      if (!data || data.length === 0) break;
+
+      const updates = data.map((r: any) => {
+        const scores = computeScores(r);
+        return { row_id: r.row_id, imported_at: r.imported_at, ...scores };
+      });
+
+      await supabase.from('product_scores').upsert(updates);
+      processed += updates.length;
+      lastId = data[data.length - 1].row_id;
+      if (data.length < BATCH_SIZE) break;
+    }
+
+    return res.status(200).json({ processed });
+  } catch (err: any) {
+    console.error('rescore failed', err);
+    return res.status(500).json({ error: err.message });
+  }
+}

--- a/sql/20241017_alter_blackbox_rows.sql
+++ b/sql/20241017_alter_blackbox_rows.sql
@@ -44,7 +44,7 @@ SELECT
   r.id AS row_id,
   r.file_id,
   r.row_index,
-  r.created_at,
+  r.imported_at,
   r.asin,
   r.url,
   r.title,

--- a/sql/20241028_optimize_db.sql
+++ b/sql/20241028_optimize_db.sql
@@ -1,0 +1,14 @@
+-- Add status and processed_at tracking to uploaded files
+ALTER TABLE blackbox_files
+  ADD COLUMN IF NOT EXISTS status text DEFAULT 'pending',
+  ADD COLUMN IF NOT EXISTS processed_at timestamptz;
+
+-- Track import time on product scores for faster lookups
+ALTER TABLE product_scores
+  ADD COLUMN IF NOT EXISTS imported_at timestamptz;
+
+-- Index recent imports for quick ordering
+CREATE INDEX IF NOT EXISTS idx_blackbox_rows_imported_at ON blackbox_rows(imported_at DESC);
+
+-- Speed up high score queries
+CREATE INDEX IF NOT EXISTS idx_product_scores_platform_imported_at ON product_scores(platform_score DESC, imported_at DESC);


### PR DESCRIPTION
## Summary
- Add `/api/products/latest` endpoint to serve recent scored products with optional recommendation filter
- Introduce `/api/products/rescore` to recompute scores in batches for rows lacking scores
- Enforce scoring on upload and in worker, skipping zero-score rows and tracking file processing status
- Update product and recommendation pages to consume latest-products API
- Optimize database with new indexes and tracking columns

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab26375b18832597c7a66fbc6e4315