### PR TITLE
Add rescore button to products page

### DIFF
--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -113,7 +113,7 @@ export default function ProductsPage() {
     try {
       const res = await fetch('/api/products/rescore', { method: 'POST' });
       const data = await res.json();
-      alert(`rescored: ${data.rescored}, zeroItems: ${data.zeroItems}`);
+      alert(`rescored: ${data.rescored}, zeroItems: ${data.zeroItems ?? 0}`);
       setFilters((f) => ({ ...f }));
     } catch (err) {
       console.error('rescore products failed', err);

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -109,6 +109,17 @@ export default function ProductsPage() {
     }
   }
 
+  async function handleRescore() {
+    try {
+      const res = await fetch('/api/products/rescore', { method: 'POST' });
+      const data = await res.json();
+      alert(`rescored: ${data.rescored}, zeroItems: ${data.zeroItems}`);
+      setFilters((f) => ({ ...f }));
+    } catch (err) {
+      console.error('rescore products failed', err);
+    }
+  }
+
   const display = [...items];
   if (sortKey) {
     display.sort((a, b) => {
@@ -144,7 +155,15 @@ export default function ProductsPage() {
 
   return (
     <div className="p-6 space-y-4 overflow-auto">
-      <h1 className="text-2xl font-semibold">产品列表</h1>
+      <div className="flex items-center">
+        <h1 className="text-2xl font-semibold">产品列表</h1>
+        <button
+          className="ml-auto px-3 py-1 border"
+          onClick={handleRescore}
+        >
+          重新评分
+        </button>
+      </div>
       <div className="flex flex-wrap items-end gap-2">
         <div>
           <label className="block text-xs">平台评分</label>

--- a/pages/api/products/rescore.ts
+++ b/pages/api/products/rescore.ts
@@ -26,5 +26,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
   }
 
-  return res.status(200).json({ rescored });
+  const { count: zeroItems, error: zeroErr } = await supabase
+    .from('product_scores')
+    .select('row_id', { count: 'exact', head: true })
+    .eq('platform_score', 0)
+    .eq('independent_score', 0);
+  if (zeroErr) return res.status(500).json({ error: zeroErr.message });
+
+  return res.status(200).json({ rescored, zeroItems });
 }


### PR DESCRIPTION
## Summary
- add `handleRescore` to trigger `/api/products/rescore`
- add top-right "重新评分" button on the products list

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abe73dd2dc8325a62263aeb568075c