### PR TITLE
feat: expand recommendation limit and add date filter

### DIFF
--- a/app/recommendations/page.tsx
+++ b/app/recommendations/page.tsx
@@ -28,8 +28,14 @@ type Product = {
   import_at: string | null;
 };
 
+type Filters = {
+  keyword: string;
+  category: string;
+  startDate: string;
+};
+
 export default function RecommendationsPage() {
-  const FETCH_LIMIT = 200;
+  const FETCH_LIMIT = 500;
   const [items, setItems] = useState<Product[]>([]);
   const [sortKey, setSortKey] = useState<keyof Product | null>(null);
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
@@ -37,8 +43,12 @@ export default function RecommendationsPage() {
   const [limit, setLimit] = useState(10);
   const [total, setTotal] = useState(0);
   const [categories, setCategories] = useState<string[]>([]);
-  const [draft, setDraft] = useState({ keyword: '', category: '' });
-  const [filters, setFilters] = useState(draft);
+  const [draft, setDraft] = useState<Filters>({
+    keyword: '',
+    category: '',
+    startDate: '',
+  });
+  const [filters, setFilters] = useState<Filters>({ ...draft });
 
   useEffect(() => {
     async function loadCategories() {
@@ -176,11 +186,22 @@ export default function RecommendationsPage() {
             ))}
           </select>
         </div>
+        <div>
+          <label className="block text-xs">开始日期</label>
+          <input
+            type="date"
+            className="border px-1"
+            value={draft.startDate}
+            onChange={(e) =>
+              setDraft({ ...draft, startDate: e.target.value })
+            }
+          />
+        </div>
         <button
           className="border px-3 py-1"
           onClick={() => {
             setPage(1);
-            setFilters(draft);
+            setFilters({ ...draft });
           }}
         >
           搜索

--- a/pages/api/files/[id]/rows.ts
+++ b/pages/api/files/[id]/rows.ts
@@ -15,6 +15,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     independentMax,
     keyword,
     category,
+    startDate,
   } = req.query;
 
   let query = supabase
@@ -30,6 +31,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     query = query.lte('independent_score', Number(independentMax));
   if (keyword) query = query.ilike('title', `%${keyword}%`);
   if (category) query = query.eq('category', category);
+  if (startDate) {
+    const iso = new Date(String(startDate)).toISOString();
+    query = query.gte('import_at', iso);
+  }
 
   const { data, error, count } = await query
     .order('row_index', { ascending: true })


### PR DESCRIPTION
## Summary
- increase recommendation fetch limit to 500
- allow filtering recommendations by start date

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac1f3cfff0832590c983afb8391e02