### PR TITLE
feat: add third-party seller filter

### DIFF
--- a/app/recommendations/page.tsx
+++ b/app/recommendations/page.tsx
@@ -39,7 +39,12 @@ export default function RecommendationsPage() {
   const [limit, setLimit] = useState(10);
   const [total, setTotal] = useState(0);
   const [categories, setCategories] = useState<string[]>([]);
-  const [draft, setDraft] = useState({ keyword: '', category: '', startDate: '' });
+  const [draft, setDraft] = useState({
+    keyword: '',
+    category: '',
+    startDate: '',
+    thirdPartySeller: '',
+  });
   const [filters, setFilters] = useState(draft);
 
   useEffect(() => {
@@ -180,6 +185,18 @@ export default function RecommendationsPage() {
                 {c}
               </option>
             ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs">第三方卖家</label>
+          <select
+            className="border px-1"
+            value={draft.thirdPartySeller}
+            onChange={(e) => setDraft({ ...draft, thirdPartySeller: e.target.value })}
+          >
+            <option value="">全部</option>
+            <option value="Yes">是</option>
+            <option value="No">否</option>
           </select>
         </div>
         <div>

--- a/pages/api/files/[id]/rows.ts
+++ b/pages/api/files/[id]/rows.ts
@@ -16,6 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     keyword,
     category,
     startDate,
+    thirdPartySeller,
   } = req.query;
 
   let query = supabase
@@ -31,6 +32,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     query = query.lte('independent_score', Number(independentMax));
   if (keyword) query = query.ilike('title', `%${keyword}%`);
   if (category) query = query.eq('category', category);
+  if (thirdPartySeller) query = query.eq('third_party_seller', thirdPartySeller);
   if (startDate) {
     const d = new Date(startDate as string);
     if (!isNaN(d.getTime())) {


### PR DESCRIPTION
## Summary
- add third-party seller dropdown filter on recommendations page
- support filtering by third-party seller in rows API

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ac6f2ff8b48325a0b2dce93ed5f4d4