### PR TITLE
feat: add trends pages

### DIFF
--- a/app/trends/[keyword]/page.tsx
+++ b/app/trends/[keyword]/page.tsx
@@ -1,0 +1,41 @@
+import ScoreBadge from "@/components/ScoreBadge";
+
+export default function TrendDetailPage({
+  params,
+}: {
+  params: { keyword: string };
+}) {
+  const keyword = decodeURIComponent(params.keyword);
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-semibold">{keyword}</h1>
+
+      <section>
+        <h2 className="text-xl mb-2">趋势曲线</h2>
+        <div className="h-64 border border-[var(--border)] flex items-center justify-center text-sm text-muted-foreground">
+          Google vs TikTok trend chart
+        </div>
+      </section>
+
+      <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="p-4 border border-[var(--border)] rounded">
+          <h3 className="font-medium mb-2">Google</h3>
+          <p className="mb-1">
+            Score: <ScoreBadge value={80} />
+          </p>
+          <p className="mb-1">Rank: 10</p>
+          <p className="text-sm text-muted-foreground">环比变化: --</p>
+        </div>
+        <div className="p-4 border border-[var(--border)] rounded">
+          <h3 className="font-medium mb-2">TikTok</h3>
+          <p className="mb-1">
+            Score: <ScoreBadge value={75} />
+          </p>
+          <p className="mb-1">Rank: 8</p>
+          <p className="text-sm text-muted-foreground">环比变化: --</p>
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/app/trends/page.tsx
+++ b/app/trends/page.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import ScoreBadge from "@/components/ScoreBadge";
+
+type TrendItem = {
+  keyword: string;
+  trend_score: number;
+  g_score: number;
+  t_score: number;
+  rank: number;
+  sources: string[];
+};
+
+const countries = ["US", "UK", "FR", "DE"];
+const categories = [
+  { value: "shopping", label: "Shopping" },
+  { value: "tech_electronics", label: "Tech & Electronics" },
+  { value: "vehicle_transport", label: "Vehicle & Transportation" },
+];
+const windows = ["1d", "7d", "30d"];
+
+export default function TrendsPage() {
+  const [country, setCountry] = useState("US");
+  const [category, setCategory] = useState("shopping");
+  const [windowPeriod, setWindowPeriod] = useState("7d");
+  const [items, setItems] = useState<TrendItem[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const params = new URLSearchParams({
+        country,
+        category,
+        window: windowPeriod,
+      });
+      const res = await fetch(`/api/trends?${params.toString()}`).then((r) =>
+        r.json()
+      );
+      setItems(res.items || []);
+    }
+    load();
+  }, [country, category, windowPeriod]);
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Trends</h1>
+
+      <div className="flex gap-4">
+        <select
+          value={country}
+          onChange={(e) => setCountry(e.target.value)}
+          className="border px-2 py-1"
+        >
+          {countries.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="border px-2 py-1"
+        >
+          {categories.map((c) => (
+            <option key={c.value} value={c.value}>
+              {c.label}
+            </option>
+          ))}
+        </select>
+        <select
+          value={windowPeriod}
+          onChange={(e) => setWindowPeriod(e.target.value)}
+          className="border px-2 py-1"
+        >
+          {windows.map((w) => (
+            <option key={w} value={w}>
+              {w}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm border border-[var(--border)]">
+          <thead className="bg-[var(--muted)]">
+            <tr>
+              <th className="p-2 text-left">Keyword</th>
+              <th className="p-2 text-left">TrendScore</th>
+              <th className="p-2 text-left">G Score</th>
+              <th className="p-2 text-left">T Score</th>
+              <th className="p-2 text-left">Rank</th>
+              <th className="p-2 text-left">来源</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <tr
+                key={item.keyword}
+                className="border-t border-[var(--border)]"
+              >
+                <td className="p-2">
+                  <Link
+                    href={`/trends/${encodeURIComponent(item.keyword)}`}
+                    className="text-blue-600 hover:underline"
+                  >
+                    {item.keyword}
+                  </Link>
+                </td>
+                <td className="p-2">
+                  <ScoreBadge value={item.trend_score} />
+                </td>
+                <td className="p-2">
+                  <ScoreBadge value={item.g_score} />
+                </td>
+                <td className="p-2">
+                  <ScoreBadge value={item.t_score} />
+                </td>
+                <td className="p-2">{item.rank}</td>
+                <td className="p-2">{item.sources.join(", ")}</td>
+              </tr>
+            ))}
+            {!items.length && (
+              <tr>
+                <td className="p-2 text-center" colSpan={6}>
+                  暂无数据
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 const nav = [
+  { label: "Trends", href: "/trends" },
   { label: "推荐产品", href: "/recommendations" },
   { label: "产品列表", href: "/products" },
   { label: "文件导入", href: "/upload" },

--- a/components/Topbar.tsx
+++ b/components/Topbar.tsx
@@ -1,7 +1,14 @@
+import Link from "next/link";
+
 export default function Topbar() {
   return (
     <header className="h-12 border-b border-[var(--border)] bg-[var(--background)] flex items-center px-4">
-      <span className="font-medium">选品平台</span>
+      <span className="font-medium flex-1">选品平台</span>
+      <nav>
+        <Link href="/trends" className="text-blue-600 font-medium">
+          Trends
+        </Link>
+      </nav>
     </header>
   );
 }

--- a/pages/api/trends.ts
+++ b/pages/api/trends.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+type TrendItem = {
+  keyword: string;
+  trend_score: number;
+  g_score: number;
+  t_score: number;
+  rank: number;
+  sources: string[];
+};
+
+const sample: TrendItem[] = [
+  {
+    keyword: "wireless charger",
+    trend_score: 92,
+    g_score: 95,
+    t_score: 88,
+    rank: 1,
+    sources: ["google", "tiktok"],
+  },
+  {
+    keyword: "smart watch",
+    trend_score: 81,
+    g_score: 79,
+    t_score: 83,
+    rank: 2,
+    sources: ["google", "tiktok"],
+  },
+  {
+    keyword: "folding bike",
+    trend_score: 68,
+    g_score: 70,
+    t_score: 66,
+    rank: 3,
+    sources: ["google"],
+  },
+];
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  res.status(200).json({ items: sample });
+}
+


### PR DESCRIPTION
## Summary
- add Trends entry to nav and top bar
- implement trends listing and detail pages with filters
- provide mock API for trend data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad5a7460248325990455bf3c92141a